### PR TITLE
Fix for CA Upload and other Tidying

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-Diladele Web Safety 4.5 in Docker with Squid 3.15.19 
+Diladele Web Safety 4.5 in Docker with Squid 3.15.19
 =============================================
 
-This project is a fork of https://github.com/diladele/docker-websafety  Web Safety ICAP web filter running in a docker container. 
+This project is a fork of https://github.com/diladele/docker-websafety  Web Safety ICAP web filter running in a docker container.
 
 Modifications
 -------------
 
-The fork makes the following modifications to run the latest Squid version 
+The fork makes the following modifications to run the latest Squid version
 
  - Moved to use phusion/baseimage 0.9.15 for the docker container - remains on Ubuntu 14.04
  - Moved to use runit rather than supervisor
@@ -16,9 +16,9 @@ The following remains unmodified
  - Diladele Websafety 4.5 - direct from Diladele website
  - Squid 3.5.19 - compiled for Ubuntu 14.04 by Diladele
  - SQLite only in this image
-  
-Important - currently /opt/qlproxy/bin is setuid to run as the correct user  
-This might mean changes to instructions such as these http://docs.diladele.com/administrator_guide_4_5/traffic_monitoring/database/create.html  
+
+Important - currently /opt/qlproxy/bin is setuid to run as the correct user
+This might mean changes to instructions such as these http://docs.diladele.com/administrator_guide_4_5/traffic_monitoring/database/create.html
 
 
 Details / Running changes
@@ -35,7 +35,7 @@ Squid has some additional controls to ensure that the diladele processes are sta
 		    then exit 1
 	    fi
 
-This is a refinement to the suggestion here http://smarden.org/runit/faq.html#depends 
+This is a refinement to the suggestion here http://smarden.org/runit/faq.html#depends
 
 apache2 is similarly delayed to start after squid has started.
 
@@ -45,29 +45,27 @@ Note, that in the diladele restart script, a pause is used for squid which can t
     echo "Reloading Squid Proxy Server..."
     sv -w 15 restart squid
 
+The latest modifications use a config container as described here : http://container-solutions.com/understanding-volumes-docker/ 
+
+
 Use
 ---
 After cloning the project, build with
 
     ./build.sh
 
-Run with 
+Run with
 
     ./run.sh
 
-Stop with 
+Stop with
 
-    docker stop websafety
+    docker stop websafety-runtime
 
 Start again with
 
-    docker start websafety
+    docker start websafety-runtime
 
+TODO:
+Some instructions for getting running with mysql in a separate container
 
-TODO List
---------
- - volumes: sort out log areas and spool areas - cron update looks like it fails until file is touched
- - mysql: script doesn't detect mysql in another container - but does upload fine - sharing pid namespace with host works though...
- - mysql: generate an initial image configured with mysql
- - image: can we copy squid cert / settings / license in during the dockerfile build - then container ends up stateless
- - coreos + systemd unit files... 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -44,6 +44,9 @@ RUN curl http://packages.diladele.com/qlproxy/${DDWS_VER}/amd64/release/ubuntu14
 RUN /usr/lib/squid/ssl_crtd -c -s /var/spool/squid_ssldb && \
 	chown -R proxy:proxy /var/spool/squid_ssldb
 
+# too many hardlinks in phusion-basimage for crontab
+RUN touch /etc/crontab
+
 # make runit service directories
 RUN mkdir /etc/service/squid /etc/service/apache2 /etc/service/qlproxy /etc/service/wsmgr
 # copy required files

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -58,10 +58,12 @@ COPY contents/apache2 /etc/service/apache2/run
 COPY contents/reload.sh /opt/qlproxy/bin/reload.sh
 COPY contents/restart.sh /opt/qlproxy/bin/restart.sh
 COPY contents/system.json /opt/qlproxy/etc/system.json
+COPY contents/firstrun.sh /usr/local/bin/firstrun.sh
 
 # reset owner of installation path
 RUN chown -R qlproxy:qlproxy /opt/qlproxy && \
     chmod +x /opt/qlproxy/bin/* && \
+    chmod +x /usr/local/bin/firstrun.sh && \
     chmod u+s /opt/qlproxy/bin/* && \
     chmod 755 /opt/qlproxy/bin/certmgr && \
     chmod +x /etc/service/squid/run \
@@ -75,6 +77,7 @@ RUN rm -rf /var/run/squid.pid /var/run/apache2/apache2.pid
 
 # assign volumes
 VOLUME ["/opt/qlproxy/etc"]
+VOLUME ["/opt/qlproxy/var/spool"]
 VOLUME ["/etc/squid"]
 VOLUME ["/var/spool"]
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -3,7 +3,7 @@
 #
 FROM phusion/baseimage:0.9.15
 
-MAINTAINER support@diladele.com
+MAINTAINER junk@nospam.net
 
 # set configuration variables
 ENV DEBIAN_FRONTEND noninteractive
@@ -40,12 +40,12 @@ RUN curl http://packages.diladele.com/qlproxy/${DDWS_VER}/amd64/release/ubuntu14
 	a2ensite qlproxy && \
 	mkdir -p /var/log/qlproxy
 
-# reinitialize squid
-RUN /usr/lib/squid/ssl_crtd -c -s /var/spool/squid_ssldb && \
-	chown -R proxy:proxy /var/spool/squid_ssldb
-
 # too many hardlinks in phusion-basimage for crontab
 RUN touch /etc/crontab
+
+# reinitialize squid
+#RUN /usr/lib/squid/ssl_crtd -c -s /var/spool/squid_ssldb && \
+#	chown -R proxy:proxy /var/spool/squid_ssldb
 
 # make runit service directories
 RUN mkdir /etc/service/squid /etc/service/apache2 /etc/service/qlproxy /etc/service/wsmgr
@@ -63,10 +63,11 @@ COPY contents/system.json /opt/qlproxy/etc/system.json
 RUN chown -R qlproxy:qlproxy /opt/qlproxy && \
     chmod +x /opt/qlproxy/bin/* && \
     chmod u+s /opt/qlproxy/bin/* && \
+    chmod 755 /opt/qlproxy/bin/certmgr && \
     chmod +x /etc/service/squid/run \
 		/etc/service/wsmgr/run \
 		/etc/service/qlproxy/run \
-		/etc/service/apache2/run
+		/etc/service/apache2/run 
 
 # and clear the image
 RUN rm -rf /var/lib/apt/lists/*
@@ -75,8 +76,6 @@ RUN rm -rf /var/run/squid.pid /var/run/apache2/apache2.pid
 # assign volumes
 VOLUME ["/opt/qlproxy/etc"]
 VOLUME ["/etc/squid"]
-VOLUME ["/var/spool/squid"]
+VOLUME ["/var/spool"]
 
-EXPOSE 80/tcp 
-EXPOSE 3128/tcp
 CMD ["/sbin/my_init"]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -43,10 +43,6 @@ RUN curl http://packages.diladele.com/qlproxy/${DDWS_VER}/amd64/release/ubuntu14
 # too many hardlinks in phusion-basimage for crontab
 RUN touch /etc/crontab
 
-# reinitialize squid
-#RUN /usr/lib/squid/ssl_crtd -c -s /var/spool/squid_ssldb && \
-#	chown -R proxy:proxy /var/spool/squid_ssldb
-
 # make runit service directories
 RUN mkdir /etc/service/squid /etc/service/apache2 /etc/service/qlproxy /etc/service/wsmgr
 # copy required files

--- a/src/build.sh
+++ b/src/build.sh
@@ -1,4 +1,4 @@
-docker rm -f websafety
-docker rmi -f websafety
-docker build --force-rm --no-cache --rm=true -t websafety .
-docker build -t websafety .
+docker rm -f websafety-config websafety-root
+docker rmi -f websafety-root
+docker build --force-rm --no-cache --rm=true -t websafety-root .
+docker build -t websafety-root .

--- a/src/contents/firstrun.sh
+++ b/src/contents/firstrun.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+/opt/qlproxy/bin/certmgr -action="regenerate-certificate-storage"
+cd /opt/qlproxy/var/spool
+mv adblock adblock.a && mv adblock.a adblock
+mv adult adult.a && mv adult.a adult
+mv categories categories.a && mv categories.a categories
+mv categories_custom categories_custom.a && mv categories_custom.a categories_custom
+mv privacy privacy.a && mv privacy.a privacy

--- a/src/contents/squid
+++ b/src/contents/squid
@@ -16,7 +16,7 @@ SQUID_PATH=/usr/sbin/$SQUID_NAME
 SQUID_CONF=/etc/squid3/squid.conf
 SQUID_PID=/var/run/squid.pid                                                                                                                                                            ✹
 
-[[ -f "$file" ]] && rm -f "$file"
+[[ -f "$SQUID_PID" ]] && rm -f "$SQUID_PID"
 
 ulimit -n 65535 
 exec $SQUID_PATH -N -YC -f $SQUID_CONF 

--- a/src/run.sh
+++ b/src/run.sh
@@ -1,2 +1,2 @@
-docker run -it --name websafety-config -t websafety-root  /opt/qlproxy/bin/certmgr -action="regenerate-certificate-storage"
+docker run -it --name websafety-config -t websafety-root  /usr/local/bin/firstrun.sh
 docker run -d --name websafety-runtime --volumes-from websafety-config -p 80:80 -p 8080:3128 -t websafety-root

--- a/src/run.sh
+++ b/src/run.sh
@@ -1,1 +1,2 @@
-docker run -d --name websafety -p 80:80 -p 8080:3128 -t websafety
+docker run -it --name websafety-config -t websafety-root  /opt/qlproxy/bin/certmgr -action="regenerate-certificate-storage"
+docker run -d --name websafety-runtime --volumes-from websafety-config -p 80:80 -p 8080:3128 -t websafety-root


### PR DESCRIPTION
I've found the issue with the CA Upload - I'm initialising the folder using your certmgr rather than squid.
I've also made it dual container - one config container, one runtime.

Finally you'll see there's now a firstrun.sh - there's an odd 'invalid cross link' error when downloading the defn files if they're not moved.
From a quick google, I suspect this is a conflict with docker/aufs and the C code - I don't know if it's resolvable in the C code, but the firstrun.sh sorts it out.

Happy to discuss further -- I _think_ this is all the issues that I'm aware of 

Please let me know if you find any others

Ian